### PR TITLE
RFC-005: IBP Branding and Website

### DIFF
--- a/proposals/005-ibp-branding-and-website.md
+++ b/proposals/005-ibp-branding-and-website.md
@@ -1,0 +1,40 @@
+# RFC-005: IBP Branding and Website
+## Summary
+
+IBP currently does not have a well-designed branding and website that corresponds to the sophistication of the distributed infrastructure solution it provides. Branding and design are crucial to the positioning and success of IBP within the distributed infrastructure space, both in the Polkadot ecosystem and beyond.
+
+There is an IBP website at [ibp.network](https://ibp.network) mirrored by [dotters.network](https://dotters.network), but it falls short of a professional design, and completely lacks branding.
+
+Helikon Labs proposes to lead a branding and design initiative that will transform the presentation, positioning and perception of IBP, ultimately resulting in better business prospects.
+
+## Details
+
+We have been collaborating with [Klad](https://klad.design/), a competent design agency with crypto-native members around the globe. Klad, as can also be seen on their website, have successfully delivered design and branding work for the following projects by Helikon Labs:
+
+- [Chainviz](https://chainviz.app)
+- [SubVT Website](https://subvt.io)
+- [Helikon Labs Website](https://helikon.io)
+- [SubVT Website](https://subvt.io)
+- [SubVT iOS](https://apps.apple.com/tr/app/subvt/id1602653455), designed for phones, tablets and watches (same design for Android).
+
+We can provide Figma design files as a demonstration of their excellent design process, which includes:
+
+- Initial interviews to establish identity and design guidelines.
+- Moodboards and color palette selection.
+- Wireframe design.
+- UX design.
+- UI design.
+
+The complete process is carried out iteratively.
+
+Helikon Labs will lead the branding and design process and the development of the website. This RFC will be updated with budgetary details should there be sufficient interest from IBP members regarding this proposal.
+
+Beyond branding and design, the website could offer the following functionality and more:
+
+- A better-designed and more comprehensive service map with effective data visualization.
+- Detailed member profiles.
+- Information and resources for developers.
+- An integrated, up-to-date wiki.
+- Information for prospective members
+
+We look forward to contributions from the IBP members.


### PR DESCRIPTION
Replaced by RFC-007 @ #5.

~~This PR adds RFC-005, a document proposing efforts to improve the branding, design and presentation of IBP.~~

~~The RFC document can be viewed [here](https://github.com/helikon-labs/ibp-RFCs/blob/helikon-rfc-005-ibp-branding-and-website/proposals/005-ibp-branding-and-website.md).~~