### PR TITLE
RFC-006: IBP Protocol Development

### DIFF
--- a/proposals/006-ibp-protocol-development.md
+++ b/proposals/006-ibp-protocol-development.md
@@ -1,0 +1,21 @@
+# RFC-006: IBP Protocol Development
+## Summary
+
+Since the early days of IBP, there have been discussions among members regarding the development of an on-chain DAO protocol. This RFC proposes the development of a Substrate-based on-chain decentralized physical infrastructure network (DePIN) protocol followed by a meticulous RFC process.
+
+## Details
+
+Although IBP is a crypto-native organization, its current operations are entirely off-chain. There have been discussions about evolving IBP into an on-chain organization, and an initial Substrate-based [proof-of-concept blockchain protocol](https://github.com/ibp-network/ibp-node) integrated with the then-active IBP monitor was developed by [kukabi](https://github.com/kukabi) from Helikon Labs. This protocol, integrated with the then-active IBP monitor, was demonstrated to Parity in a call attended by several IBP members. However, the work was interrupted due to disagreements regarding the technical management of the effort.
+
+Transitioning IBP to an on-chain DAO would offer significant benefits, including:
+
+- On-chain governance for all technical, organizational, and budgetary decisions.
+- Ratification of existing and prospective members.
+- Signed extrinsics that enable members to join or leave service provision pools.
+- Fully transparent and accessible data on member performance and services.
+- A resilient and fail-proof runtime for managing IBP's operations.
+- The potential to evolve into a permissionless DePIN platform in the future.
+
+The potential for IBP to become a permissionless DePIN protocol was highlighted in the IBP presentation at [ParisDOTComm 2023](https://parisdotcomm.org/#talks-2023), made by Amforc and Helikon Labs on July 20, 2023, in Paris. Please view the last slide of the presentation [here](https://docs.google.com/presentation/d/1z5Av4lQM1SxU0c41Lvy8PLnFEmBrvOkgtvkng38P7cg/edit?usp=sharing).
+
+Helikon Labs proposes leading the transition of IBP to a DePIN protocol on a modest budget, incorporating a meticulous RFC process, in close collaboration with IBP members and utilizing in-house engineers as needed over a reasonable timeframe. This RFC document will be updated with budgetary, personnel, and timeline details following discussions with members, should there be sufficient interest.


### PR DESCRIPTION
This PR adds RFC-006, a document proposing the development of the on-chain IBP protocol.

The RFC document can be viewed [here](https://github.com/helikon-labs/ibp-RFCs/blob/helikon-rfc-006-ibp-protocol-development/proposals/006-ibp-protocol-development.md).