### PR TITLE
Updated RFC-007: IBP Branding and Website

### DIFF
--- a/proposals/006-branding-and-website.md
+++ b/proposals/006-branding-and-website.md
@@ -1,0 +1,35 @@
+# RFC-007: IBP Branding and Website
+
+## Summary
+
+This is a follow-up to the original [RFC-007](https://github.com/ibp-network/RFCs/pull/5) for IBP Branding and Website, posted in response to the positive sentiment from members. We received two quotes: [one from Klad](https://github.com/ibp-network/RFCs/pull/5#issuecomment-2376661573), and [the other from LoopLabs](https://github.com/ibp-network/RFCs/pull/5#issuecomment-2396606154). I had calls with both teams, and at this moment it seems more feasible to proceed with with LoopLaps due to their [offer](https://github.com/ibp-network/RFCs/pull/5#issuecomment-2396606154), and their more technical approach and background.
+
+LoopLabs' budget and time estimates, as can be seen in their [offer](https://github.com/ibp-network/RFCs/pull/5#issuecomment-2396606154), is as below:
+
+- Branding - 3850 EUR, 2-3 weeks.
+- Web design - 4620 EUR, 2 weeks.
+- Web development - 4620 EUR, 2-3 weeks.
+
+The total is 13,090 EUR. Project manager will charge $150 per hour, as is the standard. I will be happy to manage the project, but would also support any other IBP member for the role.
+
+
+## Notes and Feature Requests
+
+From [@tugytur](https://github.com/tugytur) (original [here](https://github.com/ibp-network/RFCs/pull/5#issuecomment-2366965050)):
+
+- Main visitors will be 'builders', so it should be more focused on that target group.
+- Would be nice if we had a tool that lets the visitors test the IBP performance and lets them compare with other providers so that they clearly see the advantages.
+- Status page of the global service and individual locations. We can gather the data from the new DNS setup, Prometheus, or both.
+- Grafana has a feature that lets to embed dashboards into websites, so we could have global real-time stats on the website.
+- Easy way to see the all networks we run and easily get service URLs for those networks
+- the wiki should be preferably be generated from markdown files from GitHub, this way we members can constantly update it.
+
+From [@senseless](https://github.com/senseless) (original in the Matrix channel):
+
+- Need to load services, members, etc from GitHub ([config repo](https://github.com/ibp-network/config)).
+- Loading utilization (RPC requests, etc) from Prometheus -- Talking with tugy about having him export the data to an accessible json that could be picked up for the website.
+- Loading billing, utilization and offline data from ibp-geodns - We will have stats on client requests, member assignments, a billing break down per service, per member, etc. and quorum'd data regarding members uptime and online/offline status.
+
+## Project Commencement Date
+
+The project can commence in the week of the 13th of January, 2025, as confirmed by Rob from LoopLabs in our private conversations.


### PR DESCRIPTION
This is a follow-up to the original [RFC-007](https://github.com/ibp-network/RFCs/pull/5).

The RFC document can be viewed [here](https://github.com/helikon-labs/ibp-RFCs/blob/helikon-rfc-007-update-ibp-branding-and-website/proposals/006-branding-and-website.md).