### PR TITLE
RFC-014: IBP Bandwidth Cost Reduction Measure

### DIFF
--- a/proposals/014-bandwidth-cost-reduction.md
+++ b/proposals/014-bandwidth-cost-reduction.md
@@ -1,0 +1,39 @@
+# RFC 014 – IBP Bandwidth Cost Reduction Measure
+
+## Summary
+
+This RFC is a follow-up to [RFC-013 PR](https://github.com/ibp-network/RFCs/pull/13) regarding hardware pricing reductions, and it proposes lowering bandwidth costs for all members as well, in order to guarantee a 6-month runway for IBP with DOT at $2 USD. The targets, as with RFC-013, are to:
+
+> ...reduce Treasury outflow, extend sustainability, and strengthen our commercial positioning with Parity, W3F, and other ecosystem clients.
+
+## Proposed New Pricing (Effective December 2025):
+
+| Region | Current Price per GB | Suggested Price per GB |
+|---|---:|---:|
+| Central Africa | `$0.1540` | `$0.1324` |
+| Asia | `$0.1200` | `$0.1032` |
+| Europe | `$0.1050` | `$0.0903` |
+| Middle East | `$0.1300` | `$0.1118` |
+| Oceania | `$0.1520` | `$0.1307` |
+| North America | `$0.1050` | `$0.0903` |
+| Central America | `$0.1540` | `$0.1324` |
+| South America | `$0.1700` | `$0.1462` |
+
+## Impact
+
+This roughly 14% reduction lowers the total monthly bandwidth payout from $111K down to $95K, an, when combined with the measures proposed in RFC-013, brings the total monthly burn rate down to $190K. With the current balance of 571K DOT and a conservative DOT rate of $2, this would provide IBP with a 6-month runway, during which the necessary restructuring and preparations for the next top-up can take place.
+
+## Rationale
+
+The reasoning for this RFC is the same as that of RFC-013. Please refer to the [RFC-013 PR](https://github.com/ibp-network/RFCs/pull/13) for details.
+
+---
+
+## Vote
+
+On the GitHub RFC PR:
+
+- 👍 **Thumbs up** = **Aye** (approve new pricing effective December 2025 for January 1, 2026)  
+- 👎 **Thumbs down** = **Nay** (reject proposal)
+
+No reaction = abstain.


### PR DESCRIPTION
## Summary

This RFC is a follow-up to [RFC-013](https://github.com/ibp-network/RFCs/pull/13) regarding hardware pricing reductions, and it proposes lowering bandwidth costs for all members as well, in order to guarantee a 6-month runway for IBP with the current balance of 571K DOT and a conservative DOT rate of $2.

View the full RFC attached.

---

## Vote

On the GitHub RFC PR:

- 👍 **Thumbs up** = **Aye** (approve new pricing effective December 2025)  
- 👎 **Thumbs down** = **Nay** (reject proposal)

No reaction = abstain.